### PR TITLE
Allow for use of credentials with API Discovery service

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,25 @@ Installation
         )
 
 
-(3) Add configuration to your settings
+(3) Optionally, set up Google Cloud credentials in your settings.py for use with Django Cloud Tasks. If you are using a service account, make sure the account has the "Cloud Tasks Admin" permission.
+
+    .. code-block:: python
+
+        # install these if they are not already installed
+        import google.auth
+        from google.oauth2 import service_account
+
+        # ...
+
+        # To use application default credentials:
+        google_cloud_credentials, project = google.auth.default()
+
+        # To use a service account JSON file:
+        google_cloud_credentials = service_account.Credentials.from_service_account_file(
+                '/path/to/key.json')
+
+
+(4) Add configuration to your settings
 
     .. code-block:: python
 
@@ -64,8 +82,13 @@ Installation
         # the queue. Useful for debugging. Default: True
         DJANGO_CLOUD_TASKS_BLOCK_REMOTE_TASKS = False
 
+        # Optional argument. Specify a google.auth.credentials.Credentials object to use with the API 
+        # Discovery service. Can be application default credentials or credentials generated from a 
+        # service account JSON file. Default: None
+        DJANGO_CLOUD_TASKS_CREDENTIALS = None # or google_cloud_credentials if you defined this above
 
-(4) Add cloud task views to your urls.py (must resolve to the same url as ``task_handler_root_url``)
+
+(5) Add cloud task views to your urls.py (must resolve to the same url as ``task_handler_root_url``)
 
     .. code-block:: python
 

--- a/django_cloud_tasks/apps.py
+++ b/django_cloud_tasks/apps.py
@@ -1,8 +1,6 @@
 from django.apps import AppConfig
 from django.conf import settings
 
-from .connection import connection
-
 
 class DCTConfig(AppConfig):
     name = 'django_cloud_tasks'
@@ -38,3 +36,7 @@ class DCTConfig(AppConfig):
     @classmethod
     def handler_secret(cls):
         return getattr(settings, 'DJANGO_CLOUD_TASKS_HANDLER_SECRET', None)
+
+    @classmethod
+    def google_cloud_credentials(cls):
+        return getattr(settings, 'DJANGO_CLOUD_TASKS_CREDENTIALS', None)

--- a/django_cloud_tasks/connection.py
+++ b/django_cloud_tasks/connection.py
@@ -1,5 +1,7 @@
 import googleapiclient.discovery
 
+from .apps import DCTConfig
+
 
 class cached_property(object):
     def __init__(self, fget):
@@ -17,7 +19,8 @@ class cached_property(object):
 class GoogleCloudClient(object):
     @cached_property
     def client(self):
-        client = googleapiclient.discovery.build('cloudtasks', 'v2beta3')
+        client = googleapiclient.discovery.build('cloudtasks', 'v2beta3',
+                credentials=DCTConfig.google_cloud_credentials())
         return client
 
     @cached_property

--- a/django_cloud_tasks/connection.py
+++ b/django_cloud_tasks/connection.py
@@ -1,6 +1,24 @@
 import googleapiclient.discovery
+from cachetools import Cache
 
 from .apps import DCTConfig
+
+
+class MemoryCache(Cache):
+    """
+    In-memory cache for use with API Discovery service.
+
+    Fixes https://github.com/googleapis/google-api-python-client/issues/325
+
+    Solution is from https://github.com/googleapis/google-api-python-client/issues/325#issuecomment-274349841
+    """
+    _CACHE = {}
+
+    def get(self, url):
+        return MemoryCache._CACHE.get(url)
+
+    def set(self, url, content):
+        MemoryCache._CACHE[url] = content
 
 
 class cached_property(object):
@@ -20,7 +38,8 @@ class GoogleCloudClient(object):
     @cached_property
     def client(self):
         client = googleapiclient.discovery.build('cloudtasks', 'v2beta3',
-                credentials=DCTConfig.google_cloud_credentials())
+                credentials=DCTConfig.google_cloud_credentials(), 
+                cache=MemoryCache())
         return client
 
     @cached_property

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'google-api-python-client>=1.6.4',
+        'cachetools>=4.0.0',
     ],
     license="MIT",
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,6 @@ setup(
     include_package_data=True,
     install_requires=[
         'google-api-python-client>=1.6.4',
-        'cachetools>=4.0.0',
     ],
     license="MIT",
     zip_safe=False,


### PR DESCRIPTION
Allow users to define Google Cloud credentials in their settings file and use them with the API Discovery service.

Users will need to use either the application default credentials or credentials generated from a service account file.

Application default credentials:
```python
import google.auth

credentials, project = google.auth.default()

# django_cloud_tasks settings
DJANGO_CLOUD_TASKS_CREDENTIALS = credentials
```

From a service account file:
```python
# obtain a service account file from your Google Cloud Project:
# https://console.cloud.google.com/apis/credentials
# then add the Cloud Tasks admin permission
# and finally download the file as json

from google.oauth2 import service_account

credentials = service_account.Credentials.from_service_account_file(
    '/path/to/key.json')

# django_cloud_tasks settings
DJANGO_CLOUD_TASKS_CREDENTIALS = credentials
```

If credentials are not passed (and/or DJANGO_CLOUD_TASKS_CREDENTIALS is None), `googleapiclient` uses the application default credentials.

Note: by passing credentials to the API Discovery service, the caching mechanism for the discovery docs breaks (see https://github.com/googleapis/google-api-python-client/issues/325). I implemented one of the posted solutions (https://github.com/googleapis/google-api-python-client/issues/325#issuecomment-419387788), a file-based cache, and it seemed to work fine.